### PR TITLE
fix: Add support for relative file path in link

### DIFF
--- a/src/TicketSwapErrorFormatter.php
+++ b/src/TicketSwapErrorFormatter.php
@@ -133,8 +133,8 @@ final readonly class TicketSwapErrorFormatter implements ErrorFormatter
             [
                 '{absolutePath}' => $absolutePath,
                 '{editorUrl}' => $editorUrl === null ? '' : str_replace(
-                    ['%file%', '%line%'],
-                    [$absolutePath, $line],
+                    ['%relFile%', '%file%', '%line%'],
+                    [$relativePath, $absolutePath, $line],
                     $editorUrl,
                 ),
                 '{relativePath}' => $relativePath,


### PR DESCRIPTION
Hi, first of all great project, the output looks very nice!

Since https://github.com/phpstan/phpstan-src/pull/1414 phpstan is capable of handling relative paths in editorUrl which allows links to work when phpstan is executed inside a docker container.

But with this formatter enabled the relFile param is ignored so the link doesn't work.

This PR fix this issue.

An editorUrl example: 'phpstorm://open?file=/home/kevin/projects/test/%%relFile%%&line=%%line%%' 

Regards.

Kevin
