### PR TITLE
Use phpstan.neon as default

### DIFF
--- a/src/TicketSwapErrorFormatter.php
+++ b/src/TicketSwapErrorFormatter.php
@@ -57,7 +57,7 @@ final readonly class TicketSwapErrorFormatter implements ErrorFormatter
             );
         }
 
-        $projectConfigFile = 'phpstan.php';
+        $projectConfigFile = 'phpstan.neon';
         if ($analysisResult->getProjectConfigFile() !== null) {
             $projectConfigFile = $this->relativePathHelper->getRelativePath($analysisResult->getProjectConfigFile());
         }


### PR DESCRIPTION
Even though we fetch getProjectConfigFile from the $analysisResult, it's best to fallback to the standard filename.

In our own projects, we use phpstan.php, but that's not the standard.