### PR TITLE
Check if output is decorated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["phpstan", "dev"],
     "type": "phpstan-extension",
     "require": {
-        "phpstan/phpstan": "^1.11",
+        "phpstan/phpstan": "^1.12.4",
         "php": "^8.2"
     },
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "keywords": ["phpstan", "dev"],
     "type": "phpstan-extension",
     "require": {
-        "phpstan/phpstan": "^1.12.4",
-        "php": "^8.2"
+        "php": "^8.2",
+        "phpstan/phpstan": "^1.12.4"
     },
     "license": "MIT",
     "autoload": {
@@ -19,5 +19,8 @@
                 "extension.neon"
             ]
         }
+    },
+    "config": {
+        "sort-packages": true
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d2d7c563a7a39556a77a1057060f07a2",
+    "content-hash": "d2ff8fb66eb41d7daae794181e9d99e1",
     "packages": [
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.0",
+            "version": "1.12.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "384af967d35b2162f69526c7276acadce534d0e1"
+                "reference": "ffa517cb918591b93acc9b95c0bebdcd0e4538bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/384af967d35b2162f69526c7276acadce534d0e1",
-                "reference": "384af967d35b2162f69526c7276acadce534d0e1",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/ffa517cb918591b93acc9b95c0bebdcd0e4538bd",
+                "reference": "ffa517cb918591b93acc9b95c0bebdcd0e4538bd",
                 "shasum": ""
             },
             "require": {
@@ -62,7 +62,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-08-27T09:18:05+00:00"
+            "time": "2024-09-19T07:58:01+00:00"
         }
     ],
     "packages-dev": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d2ff8fb66eb41d7daae794181e9d99e1",
+    "content-hash": "456d341fe88e737f478ae46cadcb1e3a",
     "packages": [
         {
             "name": "phpstan/phpstan",

--- a/src/TicketSwapErrorFormatter.php
+++ b/src/TicketSwapErrorFormatter.php
@@ -75,6 +75,7 @@ final readonly class TicketSwapErrorFormatter implements ErrorFormatter
                                 $error->getTip()
                             ) : null,
                             $error->getIdentifier(),
+                            $output->isDecorated(),
                         ),
                         '{identifier}' => $error->getIdentifier(),
                         '{links}' => implode([
@@ -84,6 +85,7 @@ final readonly class TicketSwapErrorFormatter implements ErrorFormatter
                                 $error->getFilePath(),
                                 $this->relativePathHelper->getRelativePath($error->getFilePath()),
                                 $this->editorUrl,
+                                $output->isDecorated(),
                             ),
                             $error->getTraitFilePath() !== null ? $this::link(
                                 $this->linkFormat,
@@ -91,6 +93,7 @@ final readonly class TicketSwapErrorFormatter implements ErrorFormatter
                                 $error->getTraitFilePath(),
                                 $this->relativePathHelper->getRelativePath($error->getTraitFilePath()),
                                 $this->editorUrl,
+                                $output->isDecorated(),
                             ) : '',
                         ]),
                     ],
@@ -122,9 +125,10 @@ final readonly class TicketSwapErrorFormatter implements ErrorFormatter
         int $line,
         string $absolutePath,
         string $relativePath,
-        ?string $editorUrl
+        ?string $editorUrl,
+        bool $isDecorated,
     ) : string {
-        if ($editorUrl === null) {
+        if (!$isDecorated || $editorUrl === null) {
             $format = self::LINK_FORMAT_WITHOUT_EDITOR;
         }
 
@@ -161,8 +165,12 @@ final readonly class TicketSwapErrorFormatter implements ErrorFormatter
         );
     }
 
-    public static function highlight(string $message, ?string $tip, ?string $identifier) : string
+    public static function highlight(string $message, ?string $tip, ?string $identifier, bool $isDecorated) : string
     {
+        if (!$isDecorated) {
+            return $message;
+        }
+
         if (str_starts_with($message, 'Ignored error pattern')) {
             return $message;
         }


### PR DESCRIPTION
When the output is not decorated (`--no-ansi`), we can skip highlighting the error, as it won't have any effect anyway.

The filenames will not be clickable and therefore we don't have to trim them.

Since `Output::isDecorated` was [recently introduced in PHPStan](https://github.com/phpstan/phpstan-src/pull/3436) we need to bump the minimum requirement to `1.12.4`

Fixes #8