### PR TITLE
Widen PHP support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,18 @@ concurrency:
 
 jobs:
     phpstan:
+        strategy:
+            fail-fast: false
+            matrix:
+              php:
+                - '7.2'
+                - '7.3'
+                - '7.4'
+                - '8.0'
+                - '8.1'
+                - '8.2'
+                - '8.3'
+
         runs-on: ubuntu-latest
 
         steps:
@@ -19,7 +31,7 @@ jobs:
             - name: Set up PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: '8.2'
+                  php-version: ${{ matrix.php }}
 
             - name: Install Composer packages
               uses: ramsey/composer-install@v3

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["phpstan", "dev"],
     "type": "phpstan-extension",
     "require": {
-        "php": "^8.2",
+        "php": "^7.2|^8.0",
         "phpstan/phpstan": "^1.12.4"
     },
     "license": "MIT",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,6 +4,6 @@ parameters:
     level: 8
     paths:
         - src
-    phpVersion: 80200
+    phpVersion: 70200
     errorFormat: ticketswap
     editorUrl: 'phpstorm://open?file=%%file%%&line=%%line%%'


### PR DESCRIPTION
I know PHP 7.2 is already EOL but hear me out

This PR widens PHP support for the formatter to match requested PHPStan version 1.12.4, which supports PHP ^7.2|^8.0
The updates are the absolute minimum necessary to allow PHP 7.2 support, no behaviour is altered, added or removed

Given supported PHPStan version supports 7.2 I think this PR could be a reasonable change