### PR TITLE
Revert PHP 7.2 support and require at least 8.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,15 +10,6 @@ concurrency:
 
 jobs:
     phpstan:
-        strategy:
-            fail-fast: false
-            matrix:
-              php:
-                - '8.1'
-                - '8.2'
-                - '8.3'
-                - '8.4'
-
         runs-on: ubuntu-latest
 
         steps:
@@ -28,7 +19,7 @@ jobs:
             - name: Set up PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: ${{ matrix.php }}
+                  php-version: '8.1'
 
             - name: Install Composer packages
               uses: ramsey/composer-install@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,6 @@ jobs:
             fail-fast: false
             matrix:
               php:
-                - '7.2'
                 - '8.3'
                 - '8.4'
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,8 @@ jobs:
             fail-fast: false
             matrix:
               php:
+                - '8.1'
+                - '8.2'
                 - '8.3'
                 - '8.4'
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["phpstan", "dev"],
     "type": "phpstan-extension",
     "require": {
-        "php": "^7.2|^8.0",
+        "php": "^8.2",
         "phpstan/phpstan": "^1.12.4"
     },
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["phpstan", "dev"],
     "type": "phpstan-extension",
     "require": {
-        "php": "^8.2",
+        "php": "^8.1",
         "phpstan/phpstan": "^1.12.4"
     },
     "license": "MIT",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "456d341fe88e737f478ae46cadcb1e3a",
+    "content-hash": "5f2f2552b7da7e6411234694404e9345",
     "packages": [
         {
             "name": "phpstan/phpstan",
@@ -72,7 +72,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.2"
+        "php": "^8.1"
     },
     "platform-dev": [],
     "plugin-api-version": "2.6.0"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,6 +4,6 @@ parameters:
     level: 8
     paths:
         - src
-    phpVersion: 70200
+    phpVersion: 80200
     errorFormat: ticketswap
     editorUrl: 'phpstorm://open?file=%%file%%&line=%%line%%'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,6 +4,6 @@ parameters:
     level: 8
     paths:
         - src
-    phpVersion: 80200
+    phpVersion: 80100
     errorFormat: ticketswap
     editorUrl: 'phpstorm://open?file=%%file%%&line=%%line%%'

--- a/src/TicketSwapErrorFormatter.php
+++ b/src/TicketSwapErrorFormatter.php
@@ -10,7 +10,7 @@ use PHPStan\Command\ErrorFormatter\ErrorFormatter;
 use PHPStan\Command\Output;
 use PHPStan\File\RelativePathHelper;
 
-final class TicketSwapErrorFormatter implements ErrorFormatter
+final readonly class TicketSwapErrorFormatter implements ErrorFormatter
 {
     private const FORMAT = "{message}\n{links}";
     private const LINK_FORMAT_DEFAULT = "↳ <href={editorUrl}>{shortPath}:{line}</>\n";
@@ -19,50 +19,24 @@ final class TicketSwapErrorFormatter implements ErrorFormatter
     private const LINK_FORMAT_PHPSTORM = "↳ file://{absolutePath}:{line}\n";
     private const LINK_FORMAT_WITHOUT_EDITOR = "↳ {relativePath}:{line}\n";
 
-    /**
-     * @var string
-     */
-    private $linkFormat;
-
-    /**
-     * @var RelativePathHelper
-     */
-    private $relativePathHelper;
-
-    /**
-     * @var CiDetectedErrorFormatter
-     */
-    private $ciDetectedErrorFormatter;
-
-    /**
-     * @var string|null
-     */
-    private $editorUrl;
+    private string $linkFormat;
 
     public function __construct(
-        RelativePathHelper $relativePathHelper,
-        CiDetectedErrorFormatter $ciDetectedErrorFormatter,
-        ?string $editorUrl = null
+        private RelativePathHelper $relativePathHelper,
+        private CiDetectedErrorFormatter $ciDetectedErrorFormatter,
+        private ?string $editorUrl,
     ) {
-        $this->editorUrl = $editorUrl;
-        $this->ciDetectedErrorFormatter = $ciDetectedErrorFormatter;
-        $this->relativePathHelper = $relativePathHelper;
         $this->linkFormat = self::getLinkFormatFromEnv();
     }
 
     public static function getLinkFormatFromEnv() : string
     {
-        if (getenv('GITHUB_ACTIONS') !== false) {
-            return self::LINK_FORMAT_GITHUB_ACTIONS;
-        }
-        if (getenv('TERMINAL_EMULATOR') !== 'JetBrains-JediTerm') {
-            return self::LINK_FORMAT_PHPSTORM;
-        }
-        if (getenv('TERM_PROGRAM') !== 'WarpTerminal') {
-            return self::LINK_FORMAT_WARP;
-        }
-
-        return self::LINK_FORMAT_DEFAULT;
+        return match (true) {
+            getenv('GITHUB_ACTIONS') !== false => self::LINK_FORMAT_GITHUB_ACTIONS,
+            getenv('TERMINAL_EMULATOR') === 'JetBrains-JediTerm' => self::LINK_FORMAT_PHPSTORM,
+            getenv('TERM_PROGRAM') === 'WarpTerminal' => self::LINK_FORMAT_WARP,
+            default => self::LINK_FORMAT_DEFAULT,
+        };
     }
 
     public function formatErrors(AnalysisResult $analysisResult, Output $output) : int
@@ -78,7 +52,7 @@ final class TicketSwapErrorFormatter implements ErrorFormatter
             $output->writeLineFormatted(
                 sprintf(
                     '<unknown location> %s',
-                    $notFileSpecificError
+                    $notFileSpecificError,
                 )
             );
         }
@@ -101,7 +75,7 @@ final class TicketSwapErrorFormatter implements ErrorFormatter
                                 $error->getTip()
                             ) : null,
                             $error->getIdentifier(),
-                            $output->isDecorated()
+                            $output->isDecorated(),
                         ),
                         '{identifier}' => $error->getIdentifier(),
                         '{links}' => implode([
@@ -111,7 +85,7 @@ final class TicketSwapErrorFormatter implements ErrorFormatter
                                 $error->getFilePath(),
                                 $this->relativePathHelper->getRelativePath($error->getFilePath()),
                                 $this->editorUrl,
-                                $output->isDecorated()
+                                $output->isDecorated(),
                             ),
                             $error->getTraitFilePath() !== null ? $this::link(
                                 $this->linkFormat,
@@ -119,11 +93,11 @@ final class TicketSwapErrorFormatter implements ErrorFormatter
                                 $error->getTraitFilePath(),
                                 $this->relativePathHelper->getRelativePath($error->getTraitFilePath()),
                                 $this->editorUrl,
-                                $output->isDecorated()
+                                $output->isDecorated(),
                             ) : '',
                         ]),
-                    ]
-                )
+                    ],
+                ),
             );
         }
 
@@ -136,7 +110,7 @@ final class TicketSwapErrorFormatter implements ErrorFormatter
             sprintf(
                 '<bg=red;options=bold>Found %d error%s</>',
                 $analysisResult->getTotalErrorsCount(),
-                $analysisResult->getTotalErrorsCount() === 1 ? '' : 's'
+                $analysisResult->getTotalErrorsCount() === 1 ? '' : 's',
             )
         );
         $output->writeLineFormatted('');
@@ -152,7 +126,7 @@ final class TicketSwapErrorFormatter implements ErrorFormatter
         string $absolutePath,
         string $relativePath,
         ?string $editorUrl,
-        bool $isDecorated
+        bool $isDecorated,
     ) : string {
         if (!$isDecorated || $editorUrl === null) {
             $format = self::LINK_FORMAT_WITHOUT_EDITOR;
@@ -165,12 +139,12 @@ final class TicketSwapErrorFormatter implements ErrorFormatter
                 '{editorUrl}' => $editorUrl === null ? '' : str_replace(
                     ['%relFile%', '%file%', '%line%'],
                     [$relativePath, $absolutePath, $line],
-                    $editorUrl
+                    $editorUrl,
                 ),
                 '{relativePath}' => $relativePath,
                 '{shortPath}' => self::trimPath($relativePath),
                 '{line}' => $line,
-            ]
+            ],
         );
     }
 
@@ -183,11 +157,11 @@ final class TicketSwapErrorFormatter implements ErrorFormatter
 
         return implode(
             DIRECTORY_SEPARATOR,
-            array_merge(
-                array_slice($parts, 0, 3),
-                ['...'],
-                array_slice($parts, -2)
-            )
+            [
+                ...array_slice($parts, 0, 3),
+                '...',
+                ...array_slice($parts, -2),
+            ],
         );
     }
 
@@ -197,7 +171,7 @@ final class TicketSwapErrorFormatter implements ErrorFormatter
             return $message;
         }
 
-        if (strpos($message, 'Ignored error pattern') === 0) {
+        if (str_starts_with($message, 'Ignored error pattern')) {
             return $message;
         }
 
@@ -208,42 +182,42 @@ final class TicketSwapErrorFormatter implements ErrorFormatter
         $message = (string) preg_replace(
             "/([A-Z0-9]{1}[A-Za-z0-9_\-]+[\\\]+[A-Z0-9]{1}[A-Za-z0-9_\-\\\]+)/",
             '<fg=yellow>$1</>',
-            $message
+            $message,
         );
 
         // Quoted strings
         $message = (string) preg_replace(
             "/(?<=[\"'])([A-Za-z0-9_\-\\\]+)(?=[\"'])/",
             '<fg=yellow>$1</>',
-            $message
+            $message,
         );
 
         // Variable
         $message = (string) preg_replace(
             "/(?<=[:]{2}|[\s\"\(])([.]{3})?(\\$[A-Za-z0-9_\\-]+)(?=[\s|\"|\)]|$)/",
             '<fg=green>$1$2</>',
-            $message
+            $message,
         );
 
         // Method
         $message = (string) preg_replace(
             '/(?<=[:]{2}|[\s])(\w+\(\))/',
             '<fg=blue>$1</>',
-            $message
+            $message,
         );
 
         // Function
         $message = (string) preg_replace(
             '/(?<=function\s)(\w+)(?=\s)/',
             '<fg=blue>$1</>',
-            $message
+            $message,
         );
 
         // Types
         $message = (string) preg_replace(
             '/(?<=[\s\|\(><])(null|true|false|int|float|bool|([-\w]+-)?string|array|object|mixed|resource|iterable|void|callable)(?=[:]{2}|[\.\s\|><,\(\)\{\}]+)/',
             '<fg=magenta>$1</>',
-            $message
+            $message,
         );
 
         if ($tip !== null) {

--- a/src/TicketSwapErrorFormatter.php
+++ b/src/TicketSwapErrorFormatter.php
@@ -10,7 +10,7 @@ use PHPStan\Command\ErrorFormatter\ErrorFormatter;
 use PHPStan\Command\Output;
 use PHPStan\File\RelativePathHelper;
 
-final readonly class TicketSwapErrorFormatter implements ErrorFormatter
+final class TicketSwapErrorFormatter implements ErrorFormatter
 {
     private const FORMAT = "{message}\n{links}";
     private const LINK_FORMAT_DEFAULT = "↳ <href={editorUrl}>{shortPath}:{line}</>\n";
@@ -22,9 +22,9 @@ final readonly class TicketSwapErrorFormatter implements ErrorFormatter
     private string $linkFormat;
 
     public function __construct(
-        private RelativePathHelper $relativePathHelper,
-        private CiDetectedErrorFormatter $ciDetectedErrorFormatter,
-        private ?string $editorUrl,
+        private readonly RelativePathHelper $relativePathHelper,
+        private readonly CiDetectedErrorFormatter $ciDetectedErrorFormatter,
+        private readonly ?string $editorUrl,
     ) {
         $this->linkFormat = self::getLinkFormatFromEnv();
     }


### PR DESCRIPTION
@juliangut I thought about your change #10, and decided to undo it. The reason for this is that PHPStan 2.0 is in the works, and it will only support 8.1 and higher. Given that is going to be released in the coming months (?) I don't want to struggle with these old unsupported PHP versions. 
