### PR TITLE
Decorate `stdClass` type

### DIFF
--- a/src/TicketSwapErrorFormatter.php
+++ b/src/TicketSwapErrorFormatter.php
@@ -245,7 +245,7 @@ final class TicketSwapErrorFormatter implements ErrorFormatter
 
         // Types
         $message = (string) preg_replace(
-            '/(?<=[\s\|\(><])(null|true|false|int|float|bool|([-\w]+-)?string|Stringable|array|object|mixed|resource|iterable|void|callable)(?=[:]{2}|[\.\s\|><,\(\)\{\}]+)/',
+            '/(?<=[\s\|\(><])(null|true|false|int|float|bool|([-\w]+-)?string|Stringable|array|object|mixed|resource|iterable|void|callable|stdClass)(?=[:]{2}|[\.\s\|><,\(\)\{\}]+)/',
             '<fg=magenta>$1</>',
             $message,
         );

--- a/tests/TicketSwapErrorFormatterTest.php
+++ b/tests/TicketSwapErrorFormatterTest.php
@@ -218,7 +218,7 @@ final class TicketSwapErrorFormatterTest extends TestCase
             true
         ];
         yield [
-            'Property <fg=yellow>App\Models\ExampleModel::$example_property</> (<fg=magenta>stdClass</>|<fg=magenta>null</>) does not accept <fg=magenta>mixed</>.',
+            'Property <fg=yellow>App\Models\ExampleModel</>::<fg=green>$example_property</> (<fg=magenta>stdClass</>|<fg=magenta>null</>) does not accept <fg=magenta>mixed</>.',
             'Property App\Models\ExampleModel::$example_property (stdClass|null) does not accept mixed.',
             null,
             null,

--- a/tests/TicketSwapErrorFormatterTest.php
+++ b/tests/TicketSwapErrorFormatterTest.php
@@ -217,6 +217,13 @@ final class TicketSwapErrorFormatterTest extends TestCase
             null,
             true
         ];
+        yield [
+            'Property <fg=yellow>App\Models\ExampleModel::$example_property</> (<fg=magenta>stdClass</>|<fg=magenta>null</>) does not accept <fg=magenta>mixed</>.',
+            'Property App\Models\ExampleModel::$example_property (stdClass|null) does not accept mixed.',
+            null,
+            null,
+            true,
+        ];
     }
 
     /**


### PR DESCRIPTION
Add missing stdClass to the type-regex.

Wird current master I see the follwing:
<img width="217" height="18" alt="image" src="https://github.com/user-attachments/assets/e35edc4d-4725-4e17-85fa-d3901ae910a7" />
