### PR TITLE
Do not trim paths when an AI agent is detected

### DIFF
--- a/src/AgentDetector.php
+++ b/src/AgentDetector.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TicketSwap\PHPStanErrorFormatter;
+
+// Copied from https://github.com/shipfastlabs/agent-detector/blob/main/src/AgentDetector.php
+final class AgentDetector
+{
+    public static function isAgent() : bool
+    {
+        $aiAgent = getenv('AI_AGENT');
+
+        if (is_string($aiAgent) && trim($aiAgent) !== '') {
+            return true;
+        }
+
+        $agentsWithEnvVars = [
+            'cursor' => ['CURSOR_AGENT'],
+            'gemini' => ['GEMINI_CLI'],
+            'codex' => ['CODEX_SANDBOX', 'CODEX_THREAD_ID'],
+            'augment-cli' => ['AUGMENT_AGENT'],
+            'opencode' => ['OPENCODE_CLIENT', 'OPENCODE'],
+            'amp' => ['AMP_CURRENT_THREAD_ID'],
+            'claude' => ['CLAUDECODE', 'CLAUDE_CODE'],
+            'replit' => ['REPL_ID'],
+        ];
+
+        foreach ($agentsWithEnvVars as $envVars) {
+            foreach ($envVars as $envVar) {
+                if (getenv($envVar) !== false) {
+                    return true;
+                }
+            }
+        }
+
+        if (file_exists('/opt/.devin')) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/TicketSwapErrorFormatter.php
+++ b/src/TicketSwapErrorFormatter.php
@@ -169,7 +169,7 @@ final class TicketSwapErrorFormatter implements ErrorFormatter
                     $editorUrl,
                 ),
                 '{relativePath}' => $relativePath,
-                '{shortPath}' => self::trimPath($relativePath),
+                '{shortPath}' => AgentDetector::isAgent() ? $relativePath : self::trimPath($relativePath),
                 ':{line}' => $line === 0 ? '' : ':' . $line,
                 '{line}' => $line === 0 ? '' : (string) $line,
             ],

--- a/tests/TicketSwapErrorFormatterTest.php
+++ b/tests/TicketSwapErrorFormatterTest.php
@@ -433,6 +433,31 @@ final class TicketSwapErrorFormatterTest extends TestCase
         };
     }
 
+    public function testLinkDoesNotTrimPathWhenAgent() : void
+    {
+        putenv('AI_AGENT=1');
+
+        try {
+            $result = TicketSwapErrorFormatter::link(
+                TicketSwapErrorFormatter::LINK_FORMAT_DEFAULT,
+                20,
+                self::isWindows() ? 'c:\www\project\src\Core\Admin\Controller\Dashboard\User\AddUserController.php' : '/www/project/src/Core/Admin/Controller/Dashboard/User/AddUserController.php',
+                self::isWindows() ? 'src\Core\Admin\Controller\Dashboard\User\AddUserController.php' : 'src/Core/Admin/Controller/Dashboard/User/AddUserController.php',
+                self::PHPSTORM_EDITOR_URL,
+                true,
+            );
+
+            $expectedRelativePath = self::isWindows()
+                ? 'src\Core\Admin\Controller\Dashboard\User\AddUserController.php'
+                : 'src/Core/Admin/Controller/Dashboard/User/AddUserController.php';
+
+            self::assertStringContainsString($expectedRelativePath, $result);
+            self::assertStringNotContainsString('...', $result);
+        } finally {
+            putenv('AI_AGENT');
+        }
+    }
+
     public function testFormatErrorsNoErrorsWritesNoErrorsAndReturnsZero() : void
     {
         $analysisResult = new AnalysisResult(


### PR DESCRIPTION
Agents need full file paths to correctly locate and edit files.
