### PR TITLE
Chore: Remove non used code

### DIFF
--- a/src/TicketSwapErrorFormatter.php
+++ b/src/TicketSwapErrorFormatter.php
@@ -101,7 +101,6 @@ final class TicketSwapErrorFormatter implements ErrorFormatter
                             $error->getIdentifier(),
                             $output->isDecorated(),
                         ),
-                        '{identifier}' => $error->getIdentifier(),
                         '{links}' => implode([
                             $this::link(
                                 $this->linkFormat,


### PR DESCRIPTION
### Description

- The format constant is defined as "{message}\n{links}" and does not contain an {identifier} placeholder, so 
`'{identifier}' => $error->getIdentifier()` in `strtr` had no effect and was dead code. And removed this non using replacement.